### PR TITLE
Drop nickname column from profiles

### DIFF
--- a/backend/supabase/migrations/20240622-remove-nickname-from-profiles.sql
+++ b/backend/supabase/migrations/20240622-remove-nickname-from-profiles.sql
@@ -1,0 +1,4 @@
+-- Migration: Drop nickname column from profiles if it exists
+ALTER TABLE profiles DROP COLUMN IF EXISTS nickname;
+-- To revert this migration, you can re-add the column with:
+-- ALTER TABLE profiles ADD COLUMN nickname text;

--- a/frontend/src/components/Auth.jsx
+++ b/frontend/src/components/Auth.jsx
@@ -13,7 +13,6 @@ export default function Auth() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [isRegistering, setIsRegistering] = useState(false);
-  const [username, setUsername] = useState('');
   const [formError, setFormError] = useState('');
   const [formSuccess, setFormSuccess] = useState('');
   const navigate = useNavigate();
@@ -51,11 +50,7 @@ export default function Auth() {
       ? await supabase.auth.signUp({
           email: email,
           password: password,
-          options: {
-            data: {
-              username: username,
-            },
-          },
+          options: {},
         })
       : await supabase.auth.signInWithPassword({
           email: email,
@@ -122,22 +117,6 @@ export default function Auth() {
             </Alert>
           )}
           <form onSubmit={handleAuth} className="flex flex-col gap-5">
-            {isRegistering && (
-              <div className="flex flex-col gap-1.5">
-                <Label htmlFor="username" className="text-foreground font-medium">Username</Label>
-                <Input
-                  id="username"
-                  type="text"
-                  placeholder="Your username (min 3 chars)"
-                  value={username}
-                  required
-                  minLength={3}
-                  onChange={(e) => setUsername(e.target.value)}
-                  className="bg-input text-foreground border border-border focus:ring-2 focus:ring-primary/60 focus:border-primary/80"
-                  data-testid="register-username"
-                />
-              </div>
-            )}
             <div className="flex flex-col gap-1.5">
               <Label htmlFor="email" className="text-foreground font-medium">Email</Label>
               <Input

--- a/frontend/tests/e2e/auth.setup.ts
+++ b/frontend/tests/e2e/auth.setup.ts
@@ -16,7 +16,7 @@ setup('authenticate multiple users', async ({ page }) => {
     await expect(page).toHaveURL(/\/subscribe/);
     await expect(page.locator('[data-testid="proceed-to-checkout-button"]')).toBeVisible({ timeout: 10000 });
   } else {
-    await registerAndConfirmUser(page, { usernamePrefix: 'verifiedUser' });
+    await registerAndConfirmUser(page);
     await expect(page.locator('[data-testid="proceed-to-checkout-button"]')).toBeVisible({ timeout: 10000 });
   }
   await page.context().storageState({ path: authFiles.emailVerified });
@@ -31,7 +31,7 @@ setup('authenticate multiple users', async ({ page }) => {
     await expect(page).toHaveURL(/\/app/);
     await expect(page.locator('[data-testid="new-chat-button"], nav button:has-text("+ New Chat")').first()).toBeVisible({ timeout: 10000 });
   } else {
-    await registerAndConfirmUser(page, { usernamePrefix: 'subscribedUser' });
+    await registerAndConfirmUser(page);
     await completeSubscription(page);
     await expect(page).toHaveURL(/\/app/);
     await expect(page.locator('[data-testid="new-chat-button"], nav button:has-text("+ New Chat")').first()).toBeVisible({ timeout: 10000 });

--- a/frontend/tests/e2e/utils/userFlows.ts
+++ b/frontend/tests/e2e/utils/userFlows.ts
@@ -11,7 +11,6 @@ const routes = {
 const selectors = {
   // Registration
   toggleToRegister: 'text=Need an account? Register',
-  registerUsername: '[data-testid="register-username"]',
   registerEmail: '[data-testid="register-email"]',
   registerPassword: '[data-testid="register-password"]',
   registerSubmit: '[data-testid="register-submit"]',
@@ -33,7 +32,6 @@ export const TEST_PASSWORD = 'TestPassword123!';
 export interface UserCredentials {
   email: string;
   password: string;
-  username: string;
 }
 
 /**
@@ -46,18 +44,15 @@ export interface UserCredentials {
  * @returns {Promise<UserCredentials>} The credentials of the registered user.
  */
 export async function registerAndConfirmUser(
-  page: Page,
-  { usernamePrefix = 'user' }: { usernamePrefix?: string } = {}
+  page: Page
 ): Promise<UserCredentials> {
   const email = generateUniqueEmail();
-  const username = `${usernamePrefix}${Date.now()}`;
 
   // Navigate to auth page and switch to registration form
   await page.goto(routes.auth);
   await page.click(selectors.toggleToRegister);
 
   // Fill out registration form
-  await page.fill(selectors.registerUsername, username);
   await page.fill(selectors.registerEmail, email);
   await page.fill(selectors.registerPassword, TEST_PASSWORD);
   await page.click(selectors.registerSubmit);
@@ -81,7 +76,7 @@ export async function registerAndConfirmUser(
   // We expect to be redirected to the /subscribe page for a new, unsubscribed user.
   await page.waitForURL(`**${routes.subscribe}`, { timeout: 15000 }); // Increased timeout
 
-  return { email, password: TEST_PASSWORD, username };
+  return { email, password: TEST_PASSWORD };
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "Harem",
+  "name": "wingman",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/tasks/Tasks.md
+++ b/tasks/Tasks.md
@@ -35,7 +35,7 @@
 
 # To-Do
 
-- [ ] Remove "nickname" from the profile table.
+- [x] Remove "nickname" from the profile table.
 - [ ] Add more user flows to the E2E suite up to 25-30 tests. _tests_
 - [ ] Make the E2E suite run in the three browsers. _test_
 - [ ] Create an audit / architect-mode rule that I can insert manually. _code-quality_


### PR DESCRIPTION
## Summary
- drop obsolete `nickname` field from profile table
- check off related TODO
- remove unused nickname entry from registration and e2e tests

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`
