### PR TITLE
Improve cookie consent utilities

### DIFF
--- a/frontend/src/utils/__tests__/consent.test.ts
+++ b/frontend/src/utils/__tests__/consent.test.ts
@@ -1,0 +1,43 @@
+import {
+  COOKIE_CONSENT_KEY,
+  setCookieConsent,
+  getCookieConsent,
+  clearCookieConsent,
+  isCookieConsentSet,
+  type CookieConsentValue,
+} from '../consent';
+
+describe('consent utils', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('setCookieConsent and getCookieConsent', () => {
+    it('stores and retrieves the consent value', () => {
+      setCookieConsent('accepted');
+      expect(localStorage.getItem(COOKIE_CONSENT_KEY)).toBe('accepted');
+      expect(getCookieConsent()).toBe('accepted');
+    });
+
+    it('returns null for invalid values', () => {
+      localStorage.setItem(COOKIE_CONSENT_KEY, 'maybe');
+      expect(getCookieConsent()).toBeNull();
+    });
+  });
+
+  describe('clearCookieConsent', () => {
+    it('removes the consent key from storage', () => {
+      setCookieConsent('refused');
+      clearCookieConsent();
+      expect(localStorage.getItem(COOKIE_CONSENT_KEY)).toBeNull();
+    });
+  });
+
+  describe('isCookieConsentSet', () => {
+    it('detects when consent is stored', () => {
+      expect(isCookieConsentSet()).toBe(false);
+      setCookieConsent('accepted');
+      expect(isCookieConsentSet()).toBe(true);
+    });
+  });
+});

--- a/frontend/src/utils/consent.ts
+++ b/frontend/src/utils/consent.ts
@@ -4,13 +4,18 @@
 export type CookieConsentValue = "accepted" | "refused";
 
 /**
+ * Local storage key used to persist cookie consent
+ */
+export const COOKIE_CONSENT_KEY = "cookie_consent";
+
+/**
  * Sets the user's cookie consent value in localStorage.
  *
  * @param value - The consent value to store
  */
 export function setCookieConsent(value: CookieConsentValue): void {
   if (typeof window !== "undefined") {
-    localStorage.setItem("cookie_consent", value);
+    localStorage.setItem(COOKIE_CONSENT_KEY, value);
   }
 }
 
@@ -22,7 +27,7 @@ export function setCookieConsent(value: CookieConsentValue): void {
  */
 export function getCookieConsent(): CookieConsentValue | null {
   if (typeof window === "undefined") return null;
-  const value = localStorage.getItem("cookie_consent");
+  const value = localStorage.getItem(COOKIE_CONSENT_KEY);
   if (value === "accepted" || value === "refused") return value;
   return null;
 }
@@ -32,6 +37,14 @@ export function getCookieConsent(): CookieConsentValue | null {
  */
 export function clearCookieConsent(): void {
   if (typeof window !== "undefined") {
-    localStorage.removeItem("cookie_consent");
+    localStorage.removeItem(COOKIE_CONSENT_KEY);
   }
+}
+
+/**
+ * Checks if a cookie consent value is stored.
+ */
+export function isCookieConsentSet(): boolean {
+  if (typeof window === "undefined") return false;
+  return localStorage.getItem(COOKIE_CONSENT_KEY) !== null;
 }


### PR DESCRIPTION
## Summary
- extract a constant for the cookie consent local storage key
- add `isCookieConsentSet` helper
- create unit tests for consent utilities

## Testing
- `npm test`