### PR TITLE
Refactor upload handling into reusable hook

### DIFF
--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -5,4 +5,5 @@ export * from "./sheet";
 export * from "./textarea";
 export * from "./alert";
 export * from "./label";
-export * from "./input"; 
+export * from "./input";
+export * from "./pill-toggle";

--- a/frontend/src/components/ui/pill-toggle.tsx
+++ b/frontend/src/components/ui/pill-toggle.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+
+/**
+ * Simple pill-shaped toggle button used to switch boolean states.
+ */
+export interface PillToggleProps {
+  active: boolean;
+  onClick: (value: boolean) => void;
+  disabled?: boolean;
+  children: React.ReactNode;
+}
+
+export function PillToggle({ active, onClick, disabled, children }: PillToggleProps) {
+  return (
+    <button
+      type="button"
+      role="button"
+      aria-pressed={active}
+      disabled={disabled}
+      tabIndex={0}
+      onClick={() => !disabled && onClick(!active)}
+      className={`
+        px-4 py-1 rounded-full font-medium transition
+        ${active ? "bg-primary text-white shadow" : "bg-muted text-foreground border border-border"}
+        ${disabled ? "opacity-60 cursor-not-allowed" : "cursor-pointer hover:shadow-md"}
+        focus:outline-none focus:ring-2 focus:ring-primary/60
+      `}
+      style={{ minWidth: 120 }}
+    >
+      {children}
+    </button>
+  );
+}

--- a/frontend/src/hooks/useFileUpload.test.ts
+++ b/frontend/src/hooks/useFileUpload.test.ts
@@ -1,0 +1,57 @@
+import { renderHook, act } from '@testing-library/react';
+import useFileUpload from './useFileUpload';
+
+describe('useFileUpload', () => {
+  beforeEach(() => {
+    global.URL.createObjectURL = jest.fn(() => 'blob:mock-url');
+    global.URL.revokeObjectURL = jest.fn();
+  });
+
+  it('adds files and creates previews', () => {
+    const { result } = renderHook(() => useFileUpload());
+    const file = new File(['content'], 'test.png', { type: 'image/png' });
+
+    act(() => {
+      result.current.addFiles([file]);
+    });
+
+    expect(result.current.selectedFiles).toHaveLength(1);
+    expect(result.current.imagePreviews).toHaveLength(1);
+    expect(result.current.imagePreviews[0].url).toBe('blob:mock-url');
+  });
+
+  it('removes image and file', () => {
+    const { result } = renderHook(() => useFileUpload());
+    const file = new File(['content'], 'test.png', { type: 'image/png' });
+
+    act(() => {
+      result.current.addFiles([file]);
+    });
+    const id = result.current.imagePreviews[0].id;
+
+    act(() => {
+      result.current.removeImage(id);
+    });
+
+    expect(result.current.imagePreviews).toHaveLength(0);
+    expect(result.current.selectedFiles).toHaveLength(0);
+    expect(global.URL.revokeObjectURL).toHaveBeenCalled();
+  });
+
+  it('clears all files and previews', () => {
+    const { result } = renderHook(() => useFileUpload());
+    const file1 = new File(['c1'], '1.png', { type: 'image/png' });
+    const file2 = new File(['c2'], '2.png', { type: 'image/png' });
+
+    act(() => {
+      result.current.addFiles([file1, file2]);
+    });
+
+    act(() => {
+      result.current.clear();
+    });
+
+    expect(result.current.imagePreviews).toHaveLength(0);
+    expect(result.current.selectedFiles).toHaveLength(0);
+  });
+});

--- a/frontend/src/hooks/useFileUpload.ts
+++ b/frontend/src/hooks/useFileUpload.ts
@@ -1,0 +1,73 @@
+import { useState, useCallback, useEffect } from "react";
+
+/**
+ * Metadata for a preview image generated from an uploaded file.
+ */
+export interface ImagePreview {
+  url: string;
+  id: string;
+  name: string;
+}
+
+/**
+ * Hook to manage file uploads and previews.
+ *
+ * @returns Utilities and state for managing uploaded files
+ */
+export default function useFileUpload() {
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [imagePreviews, setImagePreviews] = useState<ImagePreview[]>([]);
+
+  // Revoke object URLs on unmount
+  useEffect(() => {
+    return () => {
+      imagePreviews.forEach((preview) => URL.revokeObjectURL(preview.url));
+    };
+  }, [imagePreviews]);
+
+  /**
+   * Add new files and create preview metadata for them.
+   */
+  const addFiles = useCallback((files: File[]) => {
+    if (!files.length) return;
+    const newFiles: File[] = [];
+    const newPreviews: ImagePreview[] = [];
+
+    files.forEach((file, index) => {
+      const id = `${Date.now()}-${Math.random()}-${index}`;
+      const url = URL.createObjectURL(file);
+      newFiles.push(file);
+      newPreviews.push({ url, id, name: file.name });
+    });
+
+    setSelectedFiles((prev) => [...prev, ...newFiles]);
+    setImagePreviews((prev) => [...prev, ...newPreviews]);
+  }, []);
+
+  /**
+   * Remove a file/preview pair by its preview id.
+   */
+  const removeImage = useCallback((previewId: string) => {
+    setImagePreviews((prevPreviews) => {
+      const previewToRemove = prevPreviews.find((p) => p.id === previewId);
+      if (previewToRemove) {
+        URL.revokeObjectURL(previewToRemove.url);
+        setSelectedFiles((prevFiles) =>
+          prevFiles.filter((file) => file.name !== previewToRemove.name)
+        );
+      }
+      return prevPreviews.filter((p) => p.id !== previewId);
+    });
+  }, []);
+
+  /**
+   * Clear all files and previews.
+   */
+  const clear = useCallback(() => {
+    imagePreviews.forEach((preview) => URL.revokeObjectURL(preview.url));
+    setSelectedFiles([]);
+    setImagePreviews([]);
+  }, [imagePreviews]);
+
+  return { selectedFiles, imagePreviews, addFiles, removeImage, clear };
+}


### PR DESCRIPTION
## Summary
- extract upload logic into a new `useFileUpload` hook
- expose new `PillToggle` UI component
- refactor `UploadComponent` to use the hook and new component
- add unit tests for `useFileUpload`

## Testing
- `npm run lint` *(fails: Parsing error: "parserOptions.project" has been provided...)*
- `npm test`