### PR TITLE
Refactor OpenAI content handling

### DIFF
--- a/backend/controllers/analyzeController.ts
+++ b/backend/controllers/analyzeController.ts
@@ -10,6 +10,7 @@ import {
 import type { IntentMode, Stage } from "../types/prompt";
 import { runCritiqueAgent } from "../services/critiqueService";
 import { uploadFilesToStorage } from "../services/imageUploadService";
+import { toOpenAIContent } from "../utils/openaiHelpers";
 import { getPreferences, UserPrefs } from "../services/userService";
 import type { SimpPreference } from "../types/user";
 import { UploadedFile, ImageRecord } from "../services/imageUploadService";
@@ -183,17 +184,8 @@ async function generateImageDescriptionAndNickname(
   finalUserMessageContent: any[],
   openaiInstance: OpenAIService = openaiClient
 ): Promise<{ nickname: string; imageDescription: string }> {
-  // Revert to Node SDK-supported types for OpenAI Vision API
-  const descriptionPromptContent = finalUserMessageContent.map((item) => {
-    if (item.type === "text") {
-      return { type: "input_text", text: item.text };
-    } else if (item.type === "image_url") {
-      return { type: "input_image", image_url: item.image_url.url };
-    } else if (item.type === "input_text" || item.type === "input_image") {
-      return item;
-    }
-    return item;
-  });
+  // Normalise content for the OpenAI SDK
+  const descriptionPromptContent = toOpenAIContent(finalUserMessageContent);
   const prompt = getImageDescriptionAndNicknamePrompt();
   const promptText =
     typeof prompt.content === "string"
@@ -262,17 +254,8 @@ async function generateImageDescription(
   finalUserMessageContent: any[],
   openaiInstance: OpenAIService = openaiClient
 ): Promise<string> {
-  // Revert to Node SDK-supported types for OpenAI Vision API
-  const descPromptContentSubsequent = finalUserMessageContent.map((item) => {
-    if (item.type === "text") {
-      return { type: "input_text", text: item.text };
-    } else if (item.type === "image_url") {
-      return { type: "input_image", image_url: item.image_url.url };
-    } else if (item.type === "input_text" || item.type === "input_image") {
-      return item;
-    }
-    return item;
-  });
+  // Normalise content for the OpenAI SDK
+  const descPromptContentSubsequent = toOpenAIContent(finalUserMessageContent);
   const prompt = getImageDescriptionPrompt();
   const promptText =
     typeof prompt.content === "string"

--- a/backend/utils/__tests__/openaiHelpers.test.ts
+++ b/backend/utils/__tests__/openaiHelpers.test.ts
@@ -1,0 +1,23 @@
+import { toOpenAIContent } from '../openaiHelpers';
+
+describe('toOpenAIContent', () => {
+  it('converts text and image_url types to input_* variants', () => {
+    const input = [
+      { type: 'text', text: 'hello' },
+      { type: 'image_url', image_url: { url: 'http://img.com/a.jpg' } },
+    ];
+    const result = toOpenAIContent(input);
+    expect(result).toEqual([
+      { type: 'input_text', text: 'hello' },
+      { type: 'input_image', image_url: 'http://img.com/a.jpg' },
+    ]);
+  });
+
+  it('passes through already normalised items', () => {
+    const input = [
+      { type: 'input_text', text: 'hi' },
+      { type: 'input_image', image_url: 'http://img.com/b.jpg' },
+    ];
+    expect(toOpenAIContent(input)).toEqual(input);
+  });
+});

--- a/backend/utils/openaiHelpers.ts
+++ b/backend/utils/openaiHelpers.ts
@@ -1,0 +1,33 @@
+export interface RawInputItem {
+  type: string;
+  text?: string;
+  image_url?: { url: string } | string;
+}
+
+export interface OpenAIInputItem {
+  type: 'input_text' | 'input_image';
+  text?: string;
+  image_url?: string;
+}
+
+/**
+ * Converts mixed message content into the format expected by the OpenAI SDK.
+ * Items using our internal 'text' or 'image_url' shape are normalised to
+ * 'input_text' and 'input_image' respectively. Any already normalised items are
+ * returned as-is so the function can be used on previously processed arrays.
+ */
+export function toOpenAIContent(items: RawInputItem[]): OpenAIInputItem[] {
+  return items.map((item) => {
+    if (item.type === 'text') {
+      return { type: 'input_text', text: item.text };
+    }
+    if (item.type === 'image_url') {
+      const url = typeof item.image_url === 'string' ? item.image_url : item.image_url?.url;
+      return { type: 'input_image', image_url: url };
+    }
+    if (item.type === 'input_text' || item.type === 'input_image') {
+      return item as OpenAIInputItem;
+    }
+    return item as OpenAIInputItem;
+  });
+}


### PR DESCRIPTION
## Summary
- add `toOpenAIContent` helper to normalize message content for the OpenAI SDK
- use the helper in `analyzeController` for generating image prompts
- test new utility

## Testing
- `npm test --prefix backend`