### PR TITLE
Refactor chat images rendering

### DIFF
--- a/frontend/src/components/ChatHistory.tsx
+++ b/frontend/src/components/ChatHistory.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
+import ChatImages from "./ChatImages";
 
 /**
  * Message interface for ChatHistory component.
@@ -87,48 +88,16 @@ function ChatHistory({ history }: ChatHistoryProps) {
                     </div>
                   )}
 
-                  {/* ADDED: Display images if imageUrls array exists */}
-                  {message.imageUrls && message.imageUrls.length > 0 && (
-                    <div
-                      className={`mt-2 flex flex-wrap gap-2 ${
-                        isUser ? "justify-end" : "justify-start"
-                      }`}
-                    >
-                      {message.imageUrls.map((url, imgIndex) => (
-                        <div key={imgIndex} className="relative">
-                          <a
-                            href={url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="block"
-                          >
-                            <img
-                              src={url}
-                              alt={`Uploaded image ${imgIndex + 1}`}
-                              className="max-w-[150px] max-h-[150px] sm:max-w-[200px] sm:max-h-[200px] rounded object-cover border border-border hover:opacity-90 transition-opacity"
-                              style={
-                                message.failed
-                                  ? { filter: "grayscale(1)", opacity: 0.5 }
-                                  : {}
-                              }
-                              onLoad={() => {
-                                // Only count images for the latest message
-                                if (index === history.length - 1) {
-                                  setImagesLoaded((l) => l + 1);
-                                }
-                              }}
-                              data-testid="chat-message-image"
-                            />
-                          </a>
-                          {message.failed && (
-                            <div className="absolute inset-0 flex items-center justify-center bg-destructive/60 text-white font-bold text-xs rounded">
-                              Upload failed
-                            </div>
-                          )}
-                        </div>
-                      ))}
-                    </div>
-                  )}
+                  <ChatImages
+                    urls={message.imageUrls || []}
+                    failed={message.failed}
+                    align={isUser ? "end" : "start"}
+                    onImageLoad={() => {
+                      if (index === history.length - 1) {
+                        setImagesLoaded((l) => l + 1);
+                      }
+                    }}
+                  />
                   {/* Optional: Timestamp - using timestamp passed from App.tsx */}
                   {/* <p className={`text-xs mt-1 ${isUser ? 'text-blue-200' : 'text-gray-400'} text-right`}>
                     {new Date(message.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
@@ -150,42 +119,15 @@ function ChatHistory({ history }: ChatHistoryProps) {
                       {message.content}
                     </div>
                   )}
-                  {message.imageUrls && message.imageUrls.length > 0 && (
-                    <div className={`mt-2 flex flex-wrap gap-2 justify-start`}>
-                      {message.imageUrls.map((url, imgIndex) => (
-                        <div key={imgIndex} className="relative">
-                          <a
-                            href={url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="block"
-                          >
-                            <img
-                              src={url}
-                              alt={`Uploaded image ${imgIndex + 1}`}
-                              className="max-w-[150px] max-h-[150px] sm:max-w-[200px] sm:max-h-[200px] rounded object-cover border border-border hover:opacity-90 transition-opacity"
-                              style={
-                                message.failed
-                                  ? { filter: "grayscale(1)", opacity: 0.5 }
-                                  : {}
-                              }
-                              onLoad={() => {
-                                if (index === history.length - 1) {
-                                  setImagesLoaded((l) => l + 1);
-                                }
-                              }}
-                              data-testid="chat-message-image"
-                            />
-                          </a>
-                          {message.failed && (
-                            <div className="absolute inset-0 flex items-center justify-center bg-destructive/60 text-white font-bold text-xs rounded">
-                              Upload failed
-                            </div>
-                          )}
-                        </div>
-                      ))}
-                    </div>
-                  )}
+                  <ChatImages
+                    urls={message.imageUrls || []}
+                    failed={message.failed}
+                    onImageLoad={() => {
+                      if (index === history.length - 1) {
+                        setImagesLoaded((l) => l + 1);
+                      }
+                    }}
+                  />
                 </CardContent>
               </Card>
             )}

--- a/frontend/src/components/ChatImages.tsx
+++ b/frontend/src/components/ChatImages.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+
+interface ChatImagesProps {
+  urls: string[];
+  failed?: boolean;
+  align?: "start" | "end";
+  onImageLoad?: (index: number) => void;
+}
+
+export default function ChatImages({
+  urls,
+  failed = false,
+  align = "start",
+  onImageLoad,
+}: ChatImagesProps) {
+  if (!urls || urls.length === 0) return null;
+
+  return (
+    <div className={`mt-2 flex flex-wrap gap-2 justify-${align}`}>
+      {urls.map((url, idx) => (
+        <div key={idx} className="relative">
+          <a
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="block"
+          >
+            <img
+              src={url}
+              alt={`Uploaded image ${idx + 1}`}
+              className="max-w-[150px] max-h-[150px] sm:max-w-[200px] sm:max-h-[200px] rounded object-cover border border-border hover:opacity-90 transition-opacity"
+              style={failed ? { filter: "grayscale(1)", opacity: 0.5 } : {}}
+              onLoad={() => onImageLoad && onImageLoad(idx)}
+              data-testid="chat-message-image"
+            />
+          </a>
+          {failed && (
+            <div className="absolute inset-0 flex items-center justify-center bg-destructive/60 text-white font-bold text-xs rounded">
+              Upload failed
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/ChatImages.test.tsx
+++ b/frontend/src/components/__tests__/ChatImages.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import ChatImages from "../ChatImages";
+
+describe("ChatImages", () => {
+  it("renders nothing when no urls", () => {
+    const { container } = render(<ChatImages urls={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("calls onImageLoad for each image", () => {
+    const handleLoad = jest.fn();
+    render(<ChatImages urls={["img1", "img2"]} onImageLoad={handleLoad} />);
+    const images = screen.getAllByTestId("chat-message-image");
+    images.forEach((img) => {
+      fireEvent.load(img);
+    });
+    expect(handleLoad).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows failed overlay when failed", () => {
+    render(<ChatImages urls={["img1"]} failed />);
+    expect(screen.getByText(/upload failed/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- create `ChatImages` component for rendering attached images
- reuse `ChatImages` inside `ChatHistory` to remove duplicate markup
- add unit tests for `ChatImages`

## Testing
- `npm test`