### PR TITLE
Switch to private image storage

### DIFF
--- a/backend/controllers/__tests__/generateImageDescription.test.ts
+++ b/backend/controllers/__tests__/generateImageDescription.test.ts
@@ -36,7 +36,7 @@ describe("generateImageDescription", () => {
   });
 
   const sampleFinalUserMessageContent = [
-    { type: "input_image", image_url: "http://example.com/image1.jpg" },
+    { type: "input_image", image_url: "data:image/jpeg;base64,AAA" },
     { type: "input_text", text: "Image for description." },
   ];
 
@@ -59,7 +59,7 @@ describe("generateImageDescription", () => {
         role: "user",
         content: [
           { type: "input_text", text: getImageDescriptionPrompt().content },
-          { type: "input_image", image_url: "http://example.com/image1.jpg" },
+          { type: "input_image", image_url: "data:image/jpeg;base64,AAA" },
           { type: "input_text", text: "Image for description." },
         ],
       },

--- a/backend/controllers/__tests__/generateImageDescriptionAndNickname.test.ts
+++ b/backend/controllers/__tests__/generateImageDescriptionAndNickname.test.ts
@@ -33,7 +33,10 @@ describe("generateImageDescriptionAndNickname", () => {
   });
 
   const sampleFinalUserMessageContent = [
-    { type: "input_image", image_url: "http://example.com/image1.jpg" },
+    {
+      type: "input_image",
+      image_url: "data:image/jpeg;base64,AAA",
+    },
     { type: "input_text", text: "Look at this!" },
   ];
 
@@ -56,7 +59,7 @@ describe("generateImageDescriptionAndNickname", () => {
             type: "input_text",
             text: getImageDescriptionAndNicknamePrompt().content,
           },
-          { type: "input_image", image_url: "http://example.com/image1.jpg" },
+          { type: "input_image", image_url: "data:image/jpeg;base64,AAA" },
           { type: "input_text", text: "Look at this!" },
         ],
       },

--- a/backend/controllers/__tests__/uploadFilesToStorage.test.ts
+++ b/backend/controllers/__tests__/uploadFilesToStorage.test.ts
@@ -93,28 +93,18 @@ describe("uploadFilesToStorage", () => {
   it("should upload files, compress images, and return correct records and URLs", async () => {
     mockUploadFn
       .mockResolvedValueOnce({
-        data: { path: "public/user-abc/message-123/testImage-test-uuid.jpg" },
+        data: { path: "user-abc/message-123/testImage-test-uuid.jpg" },
         error: null,
       })
       .mockResolvedValueOnce({
         data: {
-          path: "public/user-abc/message-123/another-image-test-uuid.jpg",
+          path: "user-abc/message-123/another-image-test-uuid.jpg",
         },
         error: null,
       })
       .mockResolvedValueOnce({
-        data: { path: "public/user-abc/message-123/document-test-uuid.pdf" },
+        data: { path: "user-abc/message-123/document-test-uuid.pdf" },
         error: null,
-      });
-    mockGetPublicUrlFn
-      .mockReturnValueOnce({
-        data: { publicUrl: "http://s.com/testImage-test-uuid.jpg" },
-      })
-      .mockReturnValueOnce({
-        data: { publicUrl: "http://s.com/another-image-test-uuid.jpg" },
-      })
-      .mockReturnValueOnce({
-        data: { publicUrl: "http://s.com/document-test-uuid.pdf" },
       });
     const result = await uploadFilesToStorage(
       supabaseAdmin,
@@ -126,19 +116,19 @@ describe("uploadFilesToStorage", () => {
     expect(mockUploadFn).toHaveBeenCalledTimes(3);
     expect(mockUploadFn).toHaveBeenNthCalledWith(
       1,
-      "public/user-abc/message-123/testImage-test-uuid.jpg",
+      "user-abc/message-123/testImage-test-uuid.jpg",
       Buffer.from("compressed-testPNG"),
       { contentType: "image/jpeg", cacheControl: "3600" }
     );
     expect(mockUploadFn).toHaveBeenNthCalledWith(
       2,
-      "public/user-abc/message-123/another-image-test-uuid.jpg",
+      "user-abc/message-123/another-image-test-uuid.jpg",
       Buffer.from("compressed-testJPG"),
       { contentType: "image/jpeg", cacheControl: "3600" }
     );
     expect(mockUploadFn).toHaveBeenNthCalledWith(
       3,
-      "public/user-abc/message-123/document-test-uuid.pdf",
+      "user-abc/message-123/document-test-uuid.pdf",
       mockFilesBase[2].buffer,
       { contentType: "application/pdf", cacheControl: "3600" }
     );
@@ -157,11 +147,8 @@ describe("uploadFilesToStorage", () => {
       size: 8,
     };
     mockUploadFn.mockResolvedValueOnce({
-      data: { path: "public/user-abc/message-123/imageToFail-test-uuid.png" },
+      data: { path: "user-abc/message-123/imageToFail-test-uuid.png" },
       error: null,
-    });
-    mockGetPublicUrlFn.mockReturnValueOnce({
-      data: { publicUrl: "http://s.com/imageToFail-test-uuid.png" },
     });
     const consoleWarnSpy = jest
       .spyOn(console, "warn")
@@ -173,7 +160,7 @@ describe("uploadFilesToStorage", () => {
       mockUserId
     );
     expect(mockUploadFn).toHaveBeenCalledWith(
-      "public/user-abc/message-123/imageToFail-test-uuid.png",
+      "user-abc/message-123/imageToFail-test-uuid.png",
       imageToFail.buffer,
       { contentType: "image/png", cacheControl: "3600" }
     );
@@ -193,11 +180,8 @@ describe("uploadFilesToStorage", () => {
     };
     // Expecting .jpg because it's an image and compressImage mock will run
     mockUploadFn.mockResolvedValueOnce({
-      data: { path: "public/user-abc/message-123/te_t_Im_ge_-test-uuid.jpg" },
+      data: { path: "user-abc/message-123/te_t_Im_ge_-test-uuid.jpg" },
       error: null,
-    });
-    mockGetPublicUrlFn.mockReturnValueOnce({
-      data: { publicUrl: "http://s.com/te_t_Im_ge_-test-uuid.jpg" },
     });
 
     await uploadFilesToStorage(
@@ -209,7 +193,7 @@ describe("uploadFilesToStorage", () => {
 
     expect(mockedCompressImage).toHaveBeenCalledWith(specialImageFile.buffer);
     expect(mockUploadFn).toHaveBeenCalledWith(
-      "public/user-abc/message-123/te_t_Im_ge_-test-uuid.jpg", // Path should be .jpg
+      "user-abc/message-123/te_t_Im_ge_-test-uuid.jpg", // Path should be .jpg
       Buffer.from("compressed-specialPNG"), // Buffer should be the compressed one
       { contentType: "image/jpeg", cacheControl: "3600" } // ContentType should be image/jpeg
     );
@@ -260,14 +244,14 @@ describe("uploadFilesToStorage", () => {
       // 1. failCompress.png (compression fails, original uploaded with .png ext)
       .mockResolvedValueOnce({
         data: {
-          path: "public/user-abc/message-123/failCompress-test-uuid.png",
+          path: "user-abc/message-123/failCompress-test-uuid.png",
         },
         error: null,
       })
       // 2. succeedCompress.jpg (compression succeeds, uploaded with .jpg ext)
       .mockResolvedValueOnce({
         data: {
-          path: "public/user-abc/message-123/succeedCompress-test-uuid.jpg",
+          path: "user-abc/message-123/succeedCompress-test-uuid.jpg",
         },
         error: null,
       })
@@ -279,22 +263,11 @@ describe("uploadFilesToStorage", () => {
       // 4. finalSuccess.gif (compression succeeds, .jpg ext)
       .mockResolvedValueOnce({
         data: {
-          path: "public/user-abc/message-123/finalSuccess-test-uuid.jpg",
+          path: "user-abc/message-123/finalSuccess-test-uuid.jpg",
         },
         error: null,
       });
 
-    mockGetPublicUrlFn
-      .mockReturnValueOnce({
-        data: { publicUrl: "http://s.com/failCompress-test-uuid.png" },
-      }) // For failCompress.png
-      .mockReturnValueOnce({
-        data: { publicUrl: "http://s.com/succeedCompress-test-uuid.jpg" },
-      }) // For succeedCompress.jpg
-      // No getPublicUrl for uploadFail.pdf as upload failed
-      .mockReturnValueOnce({
-        data: { publicUrl: "http://s.com/finalSuccess-test-uuid.jpg" },
-      }); // For finalSuccess.gif
 
     const consoleWarnSpy = jest
       .spyOn(console, "warn")
@@ -316,25 +289,25 @@ describe("uploadFilesToStorage", () => {
     // Check calls to mockUploadFn
     expect(mockUploadFn).toHaveBeenNthCalledWith(
       1,
-      "public/user-abc/message-123/failCompress-test-uuid.png",
+      "user-abc/message-123/failCompress-test-uuid.png",
       filesForPartialFailure[0].buffer,
       { contentType: "image/png", cacheControl: "3600" }
     );
     expect(mockUploadFn).toHaveBeenNthCalledWith(
       2,
-      "public/user-abc/message-123/succeedCompress-test-uuid.jpg",
+      "user-abc/message-123/succeedCompress-test-uuid.jpg",
       Buffer.from("compressed-succeedCompressJPG"),
       { contentType: "image/jpeg", cacheControl: "3600" }
     );
     expect(mockUploadFn).toHaveBeenNthCalledWith(
       3,
-      "public/user-abc/message-123/uploadFail-test-uuid.pdf",
+      "user-abc/message-123/uploadFail-test-uuid.pdf",
       filesForPartialFailure[2].buffer,
       { contentType: "application/pdf", cacheControl: "3600" }
     );
     expect(mockUploadFn).toHaveBeenNthCalledWith(
       4,
-      "public/user-abc/message-123/finalSuccess-test-uuid.jpg",
+      "user-abc/message-123/finalSuccess-test-uuid.jpg",
       Buffer.from("compressed-finalSuccessGIF"),
       { contentType: "image/jpeg", cacheControl: "3600" }
     );
@@ -347,12 +320,6 @@ describe("uploadFilesToStorage", () => {
     expect(result.imageRecords[2].filename).toBe("finalSuccess.gif");
     expect(result.imageRecords[2].content_type).toBe("image/jpeg");
 
-    expect(result.imageUrlsForOpenAI).toHaveLength(3);
-    expect(result.imageUrlsForOpenAI).toEqual([
-      "http://s.com/failCompress-test-uuid.png",
-      "http://s.com/succeedCompress-test-uuid.jpg",
-      "http://s.com/finalSuccess-test-uuid.jpg",
-    ]);
 
     expect(consoleWarnSpy).toHaveBeenCalledWith(
       expect.stringContaining("Failed to compress image failCompress.png")
@@ -374,11 +341,8 @@ describe("uploadFilesToStorage", () => {
       size: 7,
     };
     mockUploadFn.mockResolvedValueOnce({
-      data: { path: "public/message-123/onlyImage-test-uuid.jpg" },
+      data: { path: "message-123/onlyImage-test-uuid.jpg" },
       error: null,
-    });
-    mockGetPublicUrlFn.mockReturnValueOnce({
-      data: { publicUrl: "http://s.com/onlyImage-test-uuid.jpg" },
     });
     const result = await uploadFilesToStorage(
       supabaseAdmin,
@@ -387,14 +351,14 @@ describe("uploadFilesToStorage", () => {
       null
     );
     expect(mockUploadFn).toHaveBeenCalledWith(
-      "public/message-123/onlyImage-test-uuid.jpg",
+      "message-123/onlyImage-test-uuid.jpg",
       Buffer.from("compressed-soloJPG"),
       { contentType: "image/jpeg", cacheControl: "3600" }
     );
     expect(result.imageRecords[0].content_type).toBe("image/jpeg");
   });
 
-  it("should handle cases where getPublicUrl does not return a publicUrl", async () => {
+  it("should handle cases where upload succeeds but URL is not returned", async () => {
     const imageFileToTest = {
       originalname: "noUrl.png",
       mimetype: "image/png",
@@ -402,11 +366,8 @@ describe("uploadFilesToStorage", () => {
       size: 8,
     };
     mockUploadFn.mockResolvedValueOnce({
-      data: { path: "public/user-abc/message-123/noUrl-test-uuid.jpg" },
+      data: { path: "user-abc/message-123/noUrl-test-uuid.jpg" },
       error: null,
-    });
-    mockGetPublicUrlFn.mockReturnValueOnce({
-      data: { publicUrl: null as any },
     });
     const result = await uploadFilesToStorage(
       supabaseAdmin,
@@ -414,7 +375,6 @@ describe("uploadFilesToStorage", () => {
       mockSavedMessage,
       mockUserId
     );
-    expect(result.imageUrlsForOpenAI).toEqual([]);
     expect(result.imageRecords[0].content_type).toBe("image/jpeg"); // Still compressed
   });
 

--- a/backend/controllers/analyzeController.ts
+++ b/backend/controllers/analyzeController.ts
@@ -14,6 +14,7 @@ import { toOpenAIContent } from "../utils/openaiHelpers";
 import { getPreferences, UserPrefs } from "../services/userService";
 import type { SimpPreference } from "../types/user";
 import { UploadedFile, ImageRecord } from "../services/imageUploadService";
+import { compressImage } from "../utils/imageProcessor";
 import { PromptService } from "../services/promptService";
 import { inferStage, isValidStage } from "../utils/stage";
 import { stripQuotes } from "../utils/text";
@@ -359,8 +360,7 @@ export async function analyze(req: Request, res: Response): Promise<void> {
 
     let savedMessage: MessageRecord | null = null;
     let imageRecords: ImageRecord[] = [];
-    let imageUrlsForOpenAI: string[] = [];
-    let imageUrlsForFrontend: string[] = [];
+    let base64ImagesForOpenAI: { dataUrl: string }[] = [];
 
     // --- Save the Message Stub (without AI response yet) ---
     try {
@@ -393,23 +393,25 @@ export async function analyze(req: Request, res: Response): Promise<void> {
       return;
     }
 
-    // --- Upload Files to Supabase Storage & Prepare Records ---
-    if (files.length > 0 && savedMessage) {
-      const uploadResult = await uploadFilesToStorage(
-        supabaseAdmin,
-        files,
-        savedMessage,
-        userId
-      );
-      imageRecords = uploadResult.imageRecords;
-      imageUrlsForOpenAI = uploadResult.imageUrlsForOpenAI;
-      imageUrlsForFrontend = uploadResult.imageUrlsForFrontend;
-      try {
-        await saveImageRecords(supabaseAdmin, imageRecords);
-      } catch (imageDbError: any) {
-        res.status(500).json({ error: imageDbError.message });
-        console.error("[Analyze] Error saving image records:", imageDbError);
-        return;
+    // --- Prepare images for OpenAI (compress & base64) ---
+    if (files.length > 0) {
+      for (const file of files) {
+        let processedBuffer = file.buffer;
+        let processedType = file.mimetype;
+        if (file.mimetype.startsWith("image/")) {
+          try {
+            processedBuffer = await compressImage(file.buffer);
+            processedType = "image/jpeg";
+          } catch (compressionError) {
+            console.warn(
+              `Failed to compress image ${file.originalname}: ${compressionError}`
+            );
+          }
+        }
+        const dataUrl = `data:${processedType};base64,${processedBuffer.toString(
+          "base64"
+        )}`;
+        base64ImagesForOpenAI.push({ dataUrl });
       }
     }
 
@@ -423,7 +425,7 @@ export async function analyze(req: Request, res: Response): Promise<void> {
     let promptText = newMessageText;
     if (
       (!newMessageText || newMessageText.trim() === "") &&
-      imageUrlsForOpenAI.length > 0
+      base64ImagesForOpenAI.length > 0
     ) {
       const fallbackPrompt = getFallbackImageAnalysisPrompt();
       promptText =
@@ -433,28 +435,28 @@ export async function analyze(req: Request, res: Response): Promise<void> {
     }
     // Only add the user message if there are NO images; otherwise, skip it for Vision API
     if (
-      imageUrlsForOpenAI.length === 0 &&
+      base64ImagesForOpenAI.length === 0 &&
       promptText &&
       promptText.trim() !== ""
     ) {
       finalUserMessageContent.push({ type: "input_text", text: promptText });
     }
-    if (imageUrlsForOpenAI.length > 0) {
+    if (base64ImagesForOpenAI.length > 0) {
       if (finalUserMessageContent.length === 0) {
         finalUserMessageContent.push({
           type: "input_text",
           text: "[Image(s) provided]",
         });
       }
-      imageUrlsForOpenAI.forEach((url) => {
+      base64ImagesForOpenAI.forEach((img) => {
         finalUserMessageContent.push({
           type: "input_image",
-          image_url: url,
+          image_url: img.dataUrl,
         });
       });
     }
     if (isInitialUserMessage && finalUserMessageContent.length > 0) {
-      if (imageUrlsForOpenAI.length > 0) {
+      if (base64ImagesForOpenAI.length > 0) {
         // 1. First call: get image description
         const { imageDescription } = await generateImageDescriptionAndNickname(
           finalUserMessageContent
@@ -479,7 +481,7 @@ export async function analyze(req: Request, res: Response): Promise<void> {
       }
     } else if (
       finalUserMessageContent.length > 0 &&
-      imageUrlsForOpenAI.length > 0
+      base64ImagesForOpenAI.length > 0
     ) {
       // 1. First call: get image description
       const imageDescription = await generateImageDescription(
@@ -500,6 +502,24 @@ export async function analyze(req: Request, res: Response): Promise<void> {
         generatedImageDescription
       );
       savedMessage.image_description = generatedImageDescription;
+    }
+
+    // --- Now store the uploaded files in the private bucket ---
+    if (files.length > 0 && savedMessage) {
+      const uploadResult = await uploadFilesToStorage(
+        supabaseAdmin,
+        files,
+        savedMessage,
+        userId
+      );
+      imageRecords = uploadResult.imageRecords;
+      try {
+        await saveImageRecords(supabaseAdmin, imageRecords);
+      } catch (imageDbError: any) {
+        res.status(500).json({ error: imageDbError.message });
+        console.error("[Analyze] Error saving image records:", imageDbError);
+        return;
+      }
     }
 
     // --- Use the extracted stage instead of inferring it ---


### PR DESCRIPTION
## Summary
- upload chat images after analysis to Supabase private bucket
- compress & send images to OpenAI directly via base64
- fetch signed URLs for images when loading messages
- update unit tests for new workflow

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_683b6c039144832e9d3480e6c7eac562

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Images are now compressed and converted to base64 before being analyzed by AI, improving privacy and efficiency.
- **Bug Fixes**
	- Image URLs for chat messages are now generated as temporary signed URLs, enhancing security and access control.
- **Tests**
	- Updated tests to use base64-encoded images and removed reliance on public URLs and certain storage mocks.
- **Refactor**
	- Changed the image upload process to separate AI analysis from storage upload, and removed the "public/" prefix from storage paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->